### PR TITLE
BUG: Fix xpdiff period-on-period heatmap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "xplorts"
-version = "1.0"
+version = "1.1"
 authors = [
   { name="Todd M Bailey", email="tmb@baileywick.plus.com" }
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,14 +37,14 @@ class Helpers:
     """
     Class containing unit test helper functions
     """
-    
+
     def __init__(self, test_file):
         """
         Parameters
         ----------
         test_file: str
             `__file__` attribute of the unit test script
-        
+
         Examples
         --------
         # In unit test:
@@ -52,72 +52,76 @@ class Helpers:
             helpers = helper_class(__file__)
             helpers.help_me()
         """
-        
+
         self.test_file = test_file
-    
-    
+
+
     @staticmethod
     def help_me():
         """
         Sample helper function for use in unit tests
         """
         return "no"
-    
-    
+
+
     @property
     def package_src(self):
         return package_src(self.test_file)
-    
-    
+
+
     def data_file(self, fname):
         return data_file(self.test_file, fname)
-    
-    
+
+
     def py_file(self, fname):
         return py_file(self.test_file, fname)
-    
-    
-    def run_script(self, *, script=None, module=None, 
+
+
+    def run_script(self, *, script=None, module=None,
                    options=[], data=None, show=False):
         """
         Run script
         """
         # Use -s option to show a figure after creating it.
         OPTION_SHOW = "-s"
-        
+
         assert (script is None or module is None), \
             "Conflicting script and module specifications--drop one"
         assert (script is not None or module is not None), \
             "Missing specification for script or module"
-        
+
         if isinstance(script, str):
             # Make path to named script.
             script = self.py_file(script)
         elif isinstance(script, pathlib.Path):
             # Coerce Path to string.
             script = script.resolve().as_posix()
-        
+
         if isinstance(module, str):
             # Insert module name into `script` string.
             script_args = ["-m", module]
         else:
             script_args = script
-        
-        if isinstance(data, str):
-            # Make path to named data file.
-            data = self.data_file(data)
-        
+
+        if data is None:
+            data = []
+        elif isinstance(data, str):
+            data = [data]
+
+        # Make path to each named data file.
+        data = [self.data_file(fname) for fname in data]
+
         if isinstance(options, str):
             # Split option string into list of options.
             options = str.split(options)
-            
-        xlp_options = [data] if data is not None else []
+
+        xlp_options = data.copy()
         xlp_options.extend(options)
-        
+
         if show and OPTION_SHOW not in options:
             # Use -s option to show the figure after creating it.
             xlp_options.append(OPTION_SHOW)
-            
+
         # Make new environment with PYTHONPATH to our package.
         child_pythonpath = self.package_src
         if "PYTHONPATH" in os.environ:
@@ -128,10 +132,10 @@ class Helpers:
             ])
         child_environ = os.environ.copy()
         child_environ["PYTHONPATH"] = child_pythonpath
-        
+
         # Run python as a sub-process, directed to our script or module.
-        return_code = subprocess.call(["python3", 
-                                       *script_args, 
+        return_code = subprocess.call(["python3",
+                                       *script_args,
                                        *xlp_options,
                                       ],
                                       env=child_environ)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,32 @@
+"""
+Unit tests for module diff
+
+If run as a script, the tests are run
+
+@author: Todd Bailey
+"""
+
+MODULE_NAME = "xplorts.diff"
+OPTIONS = "-d date -b industry -i oph gva hours"
+DATA = ["oph 2022Q4.csv", "oph 2023Q1.csv"]
+
+
+def test_dblprod(helper_class, show=False):
+    """
+    Run module `MODULE_NAME` with data
+    """
+    helpers = helper_class(__file__)
+    return_code = helpers.run_script(module=MODULE_NAME,
+                                     options=OPTIONS,
+                                     data=DATA,
+                                     show=show)
+    # Confirm it did not fall over.
+    assert return_code == 0
+
+#%%
+
+if __name__ == "__main__":
+    from conftest import Helpers
+
+    # Run the test function, showing the figure.
+    test_dblprod(Helpers, show=True)


### PR DESCRIPTION
xpdiff showed revisions of cumulative growth on the heatmap that claimed
to show period-on-period growth.  That is fixed by this PR.

Adds a unit test for the diff sub-module.  Previously there was none.

Fixes bug that crashed if xpdiff tried to map revisions for a single measure.
The problem was from slider widget refusing to have start and end values
the same.  Now, xpdiff includes a widget only if there is more than one measure.
